### PR TITLE
Clean state before close

### DIFF
--- a/src/bin/chameleos.rs
+++ b/src/bin/chameleos.rs
@@ -96,6 +96,7 @@ fn main() {
         }
     }
 
+    state.close();
     println!("Exiting");
 
     // TODO maybe should do some better cleanup?

--- a/src/bin/state/mod.rs
+++ b/src/bin/state/mod.rs
@@ -260,6 +260,12 @@ impl State {
             self.draw.render(wgpu);
         }
     }
+
+    pub fn close(&mut self) {
+        if let Some(wgpu) = self.wgpu.take() {
+            drop(wgpu);
+        }
+    }
 }
 
 #[allow(unused)]


### PR DESCRIPTION
## Fix crash on quit due to surface destruction order

This PR fixes a segfault occurring when quitting the application via `chamel exit`.

### What was wrong
`WgpuState` was being dropped too late, after Wayland resources had already been torn down, causing an invalid destruction sequence.

### What changed
- Added `State::close()` to explicitly drop the `WgpuState` early.
- Call `state.close()` before exiting.

### Result
The application now exits cleanly without crashing.